### PR TITLE
Add Parquet writer option autodetection

### DIFF
--- a/python/datafusion/__init__.py
+++ b/python/datafusion/__init__.py
@@ -46,7 +46,11 @@ from .context import (
     SessionContext,
     SQLOptions,
 )
-from .dataframe import DataFrame
+from .dataframe import (
+    DataFrame,
+    ParquetColumnOptions,
+    ParquetWriterOptions,
+)
 from .expr import (
     Expr,
     WindowFrame,
@@ -80,6 +84,8 @@ __all__ = [
     "ExecutionPlan",
     "Expr",
     "LogicalPlan",
+    "ParquetColumnOptions",
+    "ParquetWriterOptions",
     "RecordBatch",
     "RecordBatchStream",
     "RuntimeEnvBuilder",

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from datafusion._internal import DataFrame as DataFrameInternal
     from datafusion._internal import expr as expr_internal
 
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -112,6 +113,19 @@ class Compression(Enum):
         if self == Compression.ZSTD:
             return 4
         return None
+
+
+@dataclass
+class ParquetWriterOptions:
+    """Options for writing Parquet files."""
+
+    compression: str | Compression = Compression.ZSTD
+    compression_level: int | None = None
+
+
+@dataclass
+class ParquetColumnOptions:
+    """Placeholder for column-specific options."""
 
 
 class DataFrame:
@@ -704,7 +718,7 @@ class DataFrame:
     def write_parquet(
         self,
         path: str | pathlib.Path,
-        compression: Union[str, Compression] = Compression.ZSTD,
+        compression: Union[str, Compression, ParquetWriterOptions] = Compression.ZSTD,
         compression_level: int | None = None,
     ) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a Parquet file.
@@ -725,7 +739,13 @@ class DataFrame:
                 recommended range is 1 to 22, with the default being 4. Higher levels
                 provide better compression but slower speed.
         """
-        # Convert string to Compression enum if necessary
+        if isinstance(compression, ParquetWriterOptions):
+            if compression_level is not None:
+                msg = "compression_level should be None when using ParquetWriterOptions"
+                raise ValueError(msg)
+            self.write_parquet_with_options(path, compression)
+            return
+
         if isinstance(compression, str):
             compression = Compression.from_str(compression)
 
@@ -736,6 +756,28 @@ class DataFrame:
             compression_level = compression.get_default_level()
 
         self.df.write_parquet(str(path), compression.value, compression_level)
+
+    def write_parquet_with_options(
+        self, path: str | pathlib.Path, options: ParquetWriterOptions
+    ) -> None:
+        """Execute the :py:class:`DataFrame` and write the results to Parquet.
+
+        Args:
+            path: Destination path.
+            options: Parquet writer options.
+        """
+        compression = options.compression
+        if isinstance(compression, str):
+            compression = Compression.from_str(compression)
+
+        level = options.compression_level
+        if (
+            compression in {Compression.GZIP, Compression.BROTLI, Compression.ZSTD}
+            and level is None
+        ):
+            level = compression.get_default_level()
+
+        self.df.write_parquet(str(path), compression.value, level)
 
     def write_json(self, path: str | pathlib.Path) -> None:
         """Execute the :py:class:`DataFrame` and write the results to a JSON file.

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -27,6 +27,7 @@ import pyarrow.parquet as pq
 import pytest
 from datafusion import (
     DataFrame,
+    ParquetWriterOptions,
     SessionContext,
     WindowFrame,
     column,
@@ -1630,6 +1631,22 @@ def test_write_compressed_parquet_default_compression_level(df, tmp_path, compre
     path = tmp_path
 
     df.write_parquet(str(path), compression=compression)
+
+
+def test_write_parquet_options(df, tmp_path):
+    options = ParquetWriterOptions(compression="gzip", compression_level=6)
+    df.write_parquet(str(tmp_path), options)
+
+    result = pq.read_table(str(tmp_path)).to_pydict()
+    expected = df.to_pydict()
+
+    assert result == expected
+
+
+def test_write_parquet_options_error(df, tmp_path):
+    options = ParquetWriterOptions(compression="gzip", compression_level=6)
+    with pytest.raises(ValueError):
+        df.write_parquet(str(tmp_path), options, compression_level=1)
 
 
 def test_dataframe_export(df) -> None:


### PR DESCRIPTION
## Which issue does this PR close?

- Closes # (tracking support for fine-grained Parquet writer configuration)

## Rationale for this change

Allow `DataFrame.write_parquet` to accept either compression arguments or a `ParquetWriterOptions` instance, simplifying the API.

## What changes are included in this PR?

- Introduced `ParquetWriterOptions` and `ParquetColumnOptions` dataclasses
- Added `write_parquet_with_options` method and autodetection logic in `write_parquet`
- Exported the new classes from the package
- Added unit tests for the new behaviour

## Are these changes tested?

Yes, new tests added under `tests/test_dataframe.py`.

## Are there any user-facing changes?

`write_parquet` now accepts a `ParquetWriterOptions` instance as the second argument.

------
https://chatgpt.com/codex/tasks/task_e_685938ed416083248e907180e6358d76