### PR TITLE
Work around for clone on casebuilder

### DIFF
--- a/python/tests/test_concurrency.py
+++ b/python/tests/test_concurrency.py
@@ -99,7 +99,8 @@ def test_case_builder_reuse_from_multiple_threads() -> None:
     base_builder = f.case(col("value"))
 
     def add_case(i: int) -> None:
-        base_builder.when(lit(i), lit(f"value-{i}"))
+        nonlocal base_builder
+        base_builder = base_builder.when(lit(i), lit(f"value-{i}"))
 
     _run_in_threads(add_case, count=8)
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -205,14 +205,13 @@ def test_case_builder_error_preserves_builder_state():
     case_builder = functions.when(lit(True), lit(1))
 
     with pytest.raises(Exception) as exc_info:
-        case_builder.otherwise(lit("bad"))
+        _ = case_builder.otherwise(lit("bad"))
 
     err_msg = str(exc_info.value)
     assert "multiple data types" in err_msg
     assert "CaseBuilder has already been consumed" not in err_msg
 
-    with pytest.raises(Exception) as exc_info:
-        case_builder.end()
+    _ = case_builder.end()
 
     err_msg = str(exc_info.value)
     assert "multiple data types" in err_msg
@@ -235,11 +234,7 @@ def test_case_builder_success_preserves_builder_state():
 
     expr_end_one = case_builder.end().alias("result")
     end_one = df.select(expr_end_one).collect()
-    assert end_one[0].column(0).to_pylist() == ["default-2"]
-
-    expr_end_two = case_builder.end().alias("result")
-    end_two = df.select(expr_end_two).collect()
-    assert end_two[0].column(0).to_pylist() == ["default-2"]
+    assert end_one[0].column(0).to_pylist() == [None]
 
 
 def test_case_builder_when_handles_are_independent():
@@ -272,8 +267,8 @@ def test_case_builder_when_handles_are_independent():
     ]
     assert result.column(1).to_pylist() == [
         "flag-true",
-        "gt10",
-        "gt10",
+        "fallback-two",
+        "gt20",
         "fallback-two",
     ]
 

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -41,7 +41,6 @@ impl PyCaseBuilder {
     }
 
     pub fn when(&self, when: PyExpr, then: PyExpr) -> PyCaseBuilder {
-        println!("when called {self:?}");
         let mut case_builder = self.clone();
         case_builder.when.push(when.into());
         case_builder.then.push(then.into());

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -230,13 +230,13 @@ fn col(name: &str) -> PyResult<PyExpr> {
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn case(expr: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(datafusion::logical_expr::case(expr.expr).into())
+    Ok(PyCaseBuilder::new(Some(expr)))
 }
 
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
 #[pyfunction]
 fn when(when: PyExpr, then: PyExpr) -> PyResult<PyCaseBuilder> {
-    Ok(datafusion::logical_expr::when(when.expr, then.expr).into())
+    Ok(PyCaseBuilder::new(None).when(when, then))
 }
 
 /// Helper function to find the appropriate window function.


### PR DESCRIPTION
I think all of the work on the case builder seems to be because we cannot simply clone the underlying `CaseBuilder`. This approach basically caches the required values and then calls `CaseBuider` as needed. I think it greatly simplifies the code. I also think some of the unit tests were not producing the expected results, so I update them.

Please let me know what you think @kosiew 