### PR TITLE
Implement single point for scalar conversion from python objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,27 +138,29 @@ ignore-words-list = [
 
 [dependency-groups]
 dev = [
+    "arro3-core==0.6.5",
+    "codespell==2.4.1",
     "maturin>=1.8.1",
+    "nanoarrow==0.8.0",
     "numpy>1.25.0;python_version<'3.14'",
     "numpy>=2.3.2;python_version>='3.14'",
-    "pyarrow>=19.0.0",
     "pre-commit>=4.3.0",
-    "pyyaml>=6.0.3",
+    "pyarrow>=19.0.0",
+    "pygithub==2.5.0",
     "pytest>=7.4.4",
     "pytest-asyncio>=0.23.3",
+    "pyyaml>=6.0.3",
     "ruff>=0.9.1",
     "toml>=0.10.2",
-    "pygithub==2.5.0",
-    "codespell==2.4.1",
 ]
 docs = [
-    "sphinx>=7.1.2",
-    "pydata-sphinx-theme==0.8.0",
-    "myst-parser>=3.0.1",
-    "jinja2>=3.1.5",
     "ipython>=8.12.3",
+    "jinja2>=3.1.5",
+    "myst-parser>=3.0.1",
     "pandas>=2.0.3",
     "pickleshare>=0.7.5",
-    "sphinx-autoapi>=3.4.0",
+    "pydata-sphinx-theme==0.8.0",
     "setuptools>=75.3.0",
+    "sphinx>=7.1.2",
+    "sphinx-autoapi>=3.4.0",
 ]

--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -562,8 +562,6 @@ class Expr:
         """
         if isinstance(value, str):
             value = pa.scalar(value, type=pa.string_view())
-        if not isinstance(value, pa.Scalar):
-            value = pa.scalar(value)
         return Expr(expr_internal.RawExpr.literal(value))
 
     @staticmethod
@@ -576,7 +574,6 @@ class Expr:
         """
         if isinstance(value, str):
             value = pa.scalar(value, type=pa.string_view())
-        value = value if isinstance(value, pa.Scalar) else pa.scalar(value)
 
         return Expr(expr_internal.RawExpr.literal_with_metadata(value, metadata))
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -983,6 +983,15 @@ def test_literal_metadata(ctx):
 
 
 def test_scalar_conversion() -> None:
+    class WrappedPyArrow:
+        """Wrapper class for testing __arrow_c_array__."""
+
+        def __init__(self, val: pa.Array) -> None:
+            self.val = val
+
+        def __arrow_c_array__(self, requested_schema=None):
+            return self.val.__arrow_c_array__(requested_schema=requested_schema)
+
     expected_value = lit(1)
     assert str(expected_value) == "Expr(Int64(1))"
 
@@ -998,6 +1007,9 @@ def test_scalar_conversion() -> None:
     arro3_scalar = arro3.core.Scalar(1, type=arro3.core.DataType.int32())
     assert expected_value == lit(arro3_scalar)
 
+    generic_scalar = WrappedPyArrow(pa.array([1]))
+    assert expected_value == lit(generic_scalar)
+
     expected_value = lit([1, 2, 3])
     assert str(expected_value) == "Expr(List([1, 2, 3]))"
 
@@ -1008,6 +1020,9 @@ def test_scalar_conversion() -> None:
 
     arro3_array = arro3.core.Array([1, 2, 3], type=arro3.core.DataType.int32())
     assert expected_value == lit(arro3_array)
+
+    generic_array = WrappedPyArrow(pa.array([1, 2, 3]))
+    assert expected_value == lit(generic_array)
 
 
 def test_ensure_expr():

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,8 +22,8 @@ use parking_lot::RwLock;
 use pyo3::prelude::*;
 use pyo3::types::*;
 
+use crate::common::data_type::PyScalarValue;
 use crate::errors::PyDataFusionResult;
-use crate::utils::py_obj_to_scalar_value;
 #[pyclass(name = "Config", module = "datafusion", subclass, frozen)]
 #[derive(Clone)]
 pub(crate) struct PyConfig {
@@ -65,9 +65,9 @@ impl PyConfig {
 
     /// Set a configuration option
     pub fn set(&self, key: &str, value: Py<PyAny>, py: Python) -> PyDataFusionResult<()> {
-        let scalar_value = py_obj_to_scalar_value(py, value)?;
+        let scalar_value: PyScalarValue = value.extract(py)?;
         let mut options = self.config.write();
-        options.set(key, scalar_value.to_string().as_str())?;
+        options.set(key, scalar_value.0.to_string().as_str())?;
         Ok(())
     }
 

--- a/src/pyarrow_util.rs
+++ b/src/pyarrow_util.rs
@@ -17,8 +17,13 @@
 
 //! Conversions between PyArrow and DataFusion types
 
-use arrow::array::{Array, ArrayData};
+use std::sync::Arc;
+
+use arrow::array::{make_array, Array, ArrayData, ListArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::Field;
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
+use datafusion::common::exec_err;
 use datafusion::scalar::ScalarValue;
 use pyo3::types::{PyAnyMethods, PyList};
 use pyo3::{Bound, FromPyObject, PyAny, PyResult, Python};
@@ -26,21 +31,113 @@ use pyo3::{Bound, FromPyObject, PyAny, PyResult, Python};
 use crate::common::data_type::PyScalarValue;
 use crate::errors::PyDataFusionError;
 
+fn pyobj_extract_scalar_via_capsule(
+    value: &Bound<'_, PyAny>,
+    as_list_array: bool,
+) -> PyResult<PyScalarValue> {
+    let array_data = ArrayData::from_pyarrow_bound(value)?;
+    let array = make_array(array_data);
+
+    if as_list_array {
+        let field = Arc::new(Field::new_list_field(
+            array.data_type().clone(),
+            array.nulls().is_some(),
+        ));
+        let offsets = OffsetBuffer::from_lengths(vec![array.len()]);
+        let list_array = ListArray::new(field, offsets, array, None);
+        Ok(PyScalarValue(ScalarValue::List(Arc::new(list_array))))
+    } else {
+        let scalar = ScalarValue::try_from_array(&array, 0).map_err(PyDataFusionError::from)?;
+        Ok(PyScalarValue(scalar))
+    }
+}
+
 impl FromPyArrow for PyScalarValue {
     fn from_pyarrow_bound(value: &Bound<'_, PyAny>) -> PyResult<Self> {
         let py = value.py();
-        let typ = value.getattr("type")?;
+        let pyarrow_mod = py.import("pyarrow");
 
-        // construct pyarrow array from the python value and pyarrow type
-        let factory = py.import("pyarrow")?.getattr("array")?;
-        let args = PyList::new(py, [value])?;
-        let array = factory.call1((args, typ))?;
+        // Is it a PyArrow object?
+        if let Ok(pa) = pyarrow_mod.as_ref() {
+            let scalar_type = pa.getattr("Scalar")?;
+            if value.is_instance(&scalar_type)? {
+                let typ = value.getattr("type")?;
 
-        // convert the pyarrow array to rust array using C data interface
-        let array = arrow::array::make_array(ArrayData::from_pyarrow_bound(&array)?);
-        let scalar = ScalarValue::try_from_array(&array, 0).map_err(PyDataFusionError::from)?;
+                // construct pyarrow array from the python value and pyarrow type
+                let factory = py.import("pyarrow")?.getattr("array")?;
+                let args = PyList::new(py, [value])?;
+                let array = factory.call1((args, typ))?;
 
-        Ok(PyScalarValue(scalar))
+                return pyobj_extract_scalar_via_capsule(&array, false);
+            }
+
+            let array_type = pa.getattr("Array")?;
+            if value.is_instance(&array_type)? {
+                return pyobj_extract_scalar_via_capsule(value, true);
+            }
+        }
+
+        // Is it a NanoArrow scalar?
+        if let Ok(na) = py.import("nanoarrow") {
+            let type_name = value.get_type().repr()?;
+            if type_name.contains("nanoarrow")? && type_name.contains("Scalar")? {
+                return pyobj_extract_scalar_via_capsule(value, false);
+            }
+            let array_type = na.getattr("Array")?;
+            if value.is_instance(&array_type)? {
+                return pyobj_extract_scalar_via_capsule(value, true);
+            }
+        }
+
+        // Is it a arro3 scalar?
+        if let Ok(arro3) = py.import("arro3").and_then(|arro3| arro3.getattr("core")) {
+            let scalar_type = arro3.getattr("Scalar")?;
+            if value.is_instance(&scalar_type)? {
+                return pyobj_extract_scalar_via_capsule(value, false);
+            }
+            let array_type = arro3.getattr("Array")?;
+            if value.is_instance(&array_type)? {
+                return pyobj_extract_scalar_via_capsule(value, true);
+            }
+        }
+
+        // Does it have a PyCapsule interface but isn't one of our known libraries?
+        // If so do our "best guess". Try checking type name, and if that fails
+        // return a single value if the length is 1 and return a List value otherwise
+        if value.hasattr("__arrow_c_array__")? {
+            let type_name = value.get_type().repr()?;
+            if type_name.contains("Scalar")? {
+                return pyobj_extract_scalar_via_capsule(value, false);
+            }
+            if type_name.contains("Array")? {
+                return pyobj_extract_scalar_via_capsule(value, true);
+            }
+
+            let array_data = ArrayData::from_pyarrow_bound(value)?;
+            let array = make_array(array_data);
+            if array.len() == 1 {
+                let scalar =
+                    ScalarValue::try_from_array(&array, 0).map_err(PyDataFusionError::from)?;
+                return Ok(PyScalarValue(scalar));
+            } else {
+                let field = Arc::new(Field::new_list_field(
+                    array.data_type().clone(),
+                    array.nulls().is_some(),
+                ));
+                let offsets = OffsetBuffer::from_lengths(vec![array.len()]);
+                let list_array = ListArray::new(field, offsets, array, None);
+                return Ok(PyScalarValue(ScalarValue::List(Arc::new(list_array))));
+            }
+        }
+
+        // Last attempt - try to create a PyArrow scalar from a plain Python object
+        if let Ok(pa) = pyarrow_mod.as_ref() {
+            let scalar = pa.call_method1("scalar", (value,))?;
+
+            PyScalarValue::from_pyarrow_bound(&scalar)
+        } else {
+            exec_err!("Unable to import scalar value").map_err(PyDataFusionError::from)?
+        }
     }
 }
 

--- a/src/pyarrow_util.rs
+++ b/src/pyarrow_util.rs
@@ -83,8 +83,8 @@ impl FromPyArrow for PyScalarValue {
 
         // Is it a NanoArrow scalar?
         if let Ok(na) = py.import("nanoarrow") {
-            let type_name = value.get_type().repr()?;
-            if type_name.contains("nanoarrow")? && type_name.contains("Scalar")? {
+            let scalar_type = py.import("nanoarrow.array")?.getattr("Scalar")?;
+            if value.is_instance(&scalar_type)? {
                 return pyobj_extract_scalar_via_capsule(value, false);
             }
             let array_type = na.getattr("Array")?;

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -94,7 +94,6 @@ impl PartitionEvaluator for RustPartitionEvaluator {
     }
 
     fn evaluate_all(&mut self, values: &[ArrayRef], num_rows: usize) -> Result<ArrayRef> {
-        println!("evaluate all called with number of values {}", values.len());
         Python::attach(|py| {
             let py_values = PyList::new(
                 py,


### PR DESCRIPTION
This PR is a proposal for adding a single point where we do python object to scalar value conversion. It attempts to handle three known arrow libraries: pyarrow, nanoarrow, and arro3. It includes trying to convert any library that produces a pycapsule arrow interface. There is a fallback to take any regular Python object and try turning it into a pyarrow scalar value and then importing it.